### PR TITLE
Reload suricata with systemctl

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-pulledpork-apply
+++ b/root/etc/e-smith/events/actions/nethserver-pulledpork-apply
@@ -27,5 +27,5 @@ if [ -f /tmp/emerging.rules.tar.gz ]; then
 else
     /usr/bin/pulledpork -c /etc/pulledpork/pulledpork.conf -P -E -k
 fi
-/bin/pkill -USR2 -f suricata
+systemctl reload suricata
 exit 0


### PR DESCRIPTION
Otherwise the USR2 signal was sent also to the parent
nethserver-suricata-save event.

NethServer/dev#5756