### PR TITLE
Avoid email from cron if suricata is not running

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-pulledpork-apply
+++ b/root/etc/e-smith/events/actions/nethserver-pulledpork-apply
@@ -27,5 +27,5 @@ if [ -f /tmp/emerging.rules.tar.gz ]; then
 else
     /usr/bin/pulledpork -c /etc/pulledpork/pulledpork.conf -P -E -k
 fi
-systemctl reload suricata
+systemctl is-active --quiet suricata && systemctl reload suricata
 exit 0


### PR DESCRIPTION
After nightly signature updates, pullepork signals suricata to reload
new rules. If suricata is not running, root receives a email from cron
with the following text:

/etc/cron.daily/pulledpork:

Job for suricata.service invalid.