### PR TITLE
spec: required pulledpork7

### DIFF
--- a/nethserver-pulledpork.spec
+++ b/nethserver-pulledpork.spec
@@ -7,7 +7,8 @@ Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
 URL: %{url_prefix}/%{name}
 
-Requires: pulledpork
+Requires: pulledpork7
+Obsoletes: pulledpork
 Requires: nethserver-base
 Requires: perl-LWP-Protocol-https
 BuildRequires: nethserver-devtools


### PR DESCRIPTION
Add dependency to NethServer pulledpork7 to prevent updates from EPEL

See also NethServer/pulledpork#2

NethServer/dev#6287